### PR TITLE
Added multiple options to the show command.

### DIFF
--- a/ordinati/commands/ordinati_show.py
+++ b/ordinati/commands/ordinati_show.py
@@ -3,13 +3,38 @@ import json
 import os
 
 @click.command()
-def show():
+@click.option('-s', '--sort-by', type = click.STRING, help = 'Output to be sorted by this field (id by default).')
+@click.option('-c', '--count', default = 10, type = click.INT, help = 'Number of bookmarks to be listed (10 by default).')
+@click.option('-t', '--tag', type = click.STRING, help = 'List bookmarks containing the specified tag.')
+def show(count, sort_by, tag):
+    
     '''Shows all currently saved bookmarks'''
     
     #Expand the '~' to the user's home directory
     with open(os.path.expanduser('~/.ordinati/bookmarks.json'), 'r') as f:
         objects = json.loads(f.read())
     
+    #Filter out the bookarks which contain the tag
+    if tag:
+        tag = tag.lower()
+        objects = filter(lambda x: tag in [y.lower() for y in x['tags']], objects)
+        objects = list(objects)
+    
+    #Sort the list of objects by the key as specified
+    if sort_by:
+        objects = sorted(objects, key = lambda k: k[sort_by])
+    
+    #Set number of objects to be displayed to the count
+    objects = objects[0:count]
+    
+    #First line of output describes the options provided   
+    output_string = 'Listing {0} bookmarks'.format(count)
+    if tag:
+        output_string += ' tagged "{0}"'.format(tag)
+    if sort_by:
+        output_string += ' sorted by "{0}"'.format(sort_by)
+    output_string += ':\n'
+    click.echo(output_string)
     #Display only the name and url
     for x in objects:
         click.echo('{0}:\t{1}'.format(x['name'], x['url']))

--- a/ordinati/ordinati.py
+++ b/ordinati/ordinati.py
@@ -3,7 +3,9 @@ from .commands import ordinati_show
 
 @click.group()
 def cli():
+
     '''Offline bookmark management command line tool'''
+
     pass
     
 cli.add_command(ordinati_show.show)


### PR DESCRIPTION
1. Added a '-t, --tag' option which filters output by the specified tag.
2. Added a '-s, --sort-by' option which sorts the output by the specified field.
3. Added a '-c, --count' option which limits the number of bookmarks to be showed in output (default = 10).
4. Printing the first line (description) changes with respect to the options provided.