### PR TITLE
Basic Input Validation for ordinati show.

### DIFF
--- a/ordinati/commands/ordinati_show.py
+++ b/ordinati/commands/ordinati_show.py
@@ -4,7 +4,7 @@ import os
 import sys
 
 @click.command()
-@click.option('-s', '--sort-by', type = click.STRING, help = 'Output to be sorted by this field (id by default).')
+@click.option('-s', '--sort-by', type = click.Choice(['name', 'id', 'url']), help = 'Output to be sorted by this field (id by default).')
 @click.option('-c', '--count', default = 10, type = click.INT, help = 'Number of bookmarks to be listed (10 by default).')
 @click.option('-t', '--tag', type = click.STRING, help = 'List bookmarks containing the specified tag.')
 def show(count, sort_by, tag):
@@ -23,12 +23,7 @@ def show(count, sort_by, tag):
     
     #Sort the list of objects by the key as specified
     if sort_by:
-        if sort_by not in ['name', 'id', 'url']:
-            click.echo('Cannot sort by {0}.'.format(sort_by))
-            click.echo('Available options: name, id, url.')
-            sys.exit(0)
-        else:
-            objects = sorted(objects, key = lambda k: k[sort_by])
+        objects = sorted(objects, key = lambda k: k[sort_by])
     
     #Check to ensure count does not exceed number of objects
     if count > len(objects):

--- a/ordinati/commands/ordinati_show.py
+++ b/ordinati/commands/ordinati_show.py
@@ -1,6 +1,7 @@
 import click
 import json
 import os
+import sys
 
 @click.command()
 @click.option('-s', '--sort-by', type = click.STRING, help = 'Output to be sorted by this field (id by default).')
@@ -22,19 +23,30 @@ def show(count, sort_by, tag):
     
     #Sort the list of objects by the key as specified
     if sort_by:
-        objects = sorted(objects, key = lambda k: k[sort_by])
+        if sort_by not in ['name', 'id', 'url']:
+            click.echo('Cannot sort by {0}.'.format(sort_by))
+            click.echo('Available options: name, id, url.')
+            sys.exit(0)
+        else:
+            objects = sorted(objects, key = lambda k: k[sort_by])
     
-    #Set number of objects to be displayed to the count
-    objects = objects[0:count]
+    #Check to ensure count does not exceed number of objects
+    if count > len(objects):
+        click.echo('Warning: {0} exceeds the number of bookmarks.'.format(count))
+        click.echo('Count set to number of bookmarks instead.')
+        count = len(objects)
+    
+    #Taking only 'count' bookmarks
+    objects = objects[0:count] 
     
     #First line of output describes the options provided   
     output_string = 'Listing {0} bookmarks'.format(count)
     if tag:
-        output_string += ' tagged "{0}"'.format(tag)
+        output_string += ' tagged \'{0}\''.format(tag)
     if sort_by:
-        output_string += ' sorted by "{0}"'.format(sort_by)
+        output_string += ' sorted by \'{0}\''.format(sort_by)
     output_string += ':\n'
     click.echo(output_string)
     #Display only the name and url
     for x in objects:
-        click.echo('{0}:\t{1}'.format(x['name'], x['url']))
+        click.echo('{0}:\r\t\t{1}'.format(x['name'], x['url']))


### PR DESCRIPTION
1. The -c, --count option now gives a warning if the count exceeds the actual number of bookmarks to be displayed (Applied after filtering by tags, sorting, etc.) It changes the count to the number of bookmarks to be displayed and continues working.
2. The -s, --sort-by option only accepts name, id and url as possible keys to sort the final output by. Some form of sorting will be implemented for tags and datetime later, and they will need to be added as valid keys at that point.

The output looks prettier.